### PR TITLE
Use unpack_array for "votes" elements

### DIFF
--- a/wa_leg_api/waleg.py
+++ b/wa_leg_api/waleg.py
@@ -88,6 +88,7 @@ def unpack_thing(thing: Tag, keydict: Dict[str, Any]) -> Tuple[str, Any]:
     name = thing.name
 
     if len(thing.contents) > 1:
+        # "votes" returned by legislation.get_roll_calls is also an array
         if (thing.name.startswith("arrayof")) or (thing.name == "votes"):
             return name, unpack_array(thing, keydict)
         else:

--- a/wa_leg_api/waleg.py
+++ b/wa_leg_api/waleg.py
@@ -88,7 +88,7 @@ def unpack_thing(thing: Tag, keydict: Dict[str, Any]) -> Tuple[str, Any]:
     name = thing.name
 
     if len(thing.contents) > 1:
-        if thing.name.startswith("arrayof"):
+        if (thing.name.startswith("arrayof")) or (thing.name == "votes"):
             return name, unpack_array(thing, keydict)
         else:
             return name, unpack_struct(thing, keydict)


### PR DESCRIPTION
When calling `get_roll_calls()`, the roll call includes an array-like `<votes>` element that contains a  `<vote>` for each legislator and their vote. Previously, only the last element from this list was returned. By instead calling `unpack_array()` when `votes` is encountered, we can get all the votes.

I don't have much beautifulsoup experience – so if you'd prefer to go about this a different way please let me know, and I'm happy to make any recommended changes! I suspect there's a better way to do it than mine, but I reached for the low-hanging fruit 🙂 

Thanks for building this library! I wrote a less thorough (and very buggy) parser last time I explored this data set, and your library made accessing the data _so_ much easier.